### PR TITLE
Revert "upgraded package version"

### DIFF
--- a/plan.sh
+++ b/plan.sh
@@ -1,12 +1,12 @@
 pkg_name=linux-headers
 pkg_origin=core
-pkg_version=4.19.213
+pkg_version=4.20.17
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_description="The Linux kernel headers"
 pkg_upstream_url="https://kernel.org"
 pkg_license=('GPL-2.0-or-later')
 pkg_source="https://www.kernel.org/pub/linux/kernel/v4.x/linux-${pkg_version}.tar.xz"
-pkg_shasum=38f28c1cd6db0b54ee37a14fd17db651fe68704d08f95e141b14d32b872f4e98
+pkg_shasum="d011245629b980d4c15febf080b54804aaf215167b514a3577feddb2495f8a3e"
 pkg_dirname="linux-$pkg_version"
 pkg_deps=()
 pkg_build_deps=(


### PR DESCRIPTION
Reverts chef-base-plans/linux-headers#12

linux v4.20.x version branch is no longer maintained and patches and upgraded are not available for download. linux v4.19.x is currently maintained as LTS. Since v4.19.x would be step down vision from v4.20.x, upgrade of linux and linux-headers packages is skipped in this Package Refresh.

latest version of packages linux and linux-headers would be v4.20.17